### PR TITLE
Detect Similar Activity Names

### DIFF
--- a/app/src/main/java/de/rampro/activitydiary/helpers/JaroWinkler.java
+++ b/app/src/main/java/de/rampro/activitydiary/helpers/JaroWinkler.java
@@ -1,0 +1,177 @@
+/*
+ * ActivityDiary
+ *
+ * Copyright (C) 2018 Raphael Mack http://www.raphael-mack.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.rampro.activitydiary.helpers;
+
+import java.util.Arrays;
+
+/**
+ * The Jaro–Winkler distance metric is designed and best suited for short
+ * strings such as person names, and to detect typos; it is (roughly) a
+ * variation of Damerau-Levenshtein, where the substitution of 2 close
+ * characters is considered less important then the substitution of 2 characters
+ * that a far from each other.
+ * Jaro-Winkler was developed in the area of record linkage (duplicate
+ * detection) (Winkler, 1990). It returns a value in the interval [0.0, 1.0].
+ * The distance is computed as 1 - Jaro-Winkler similarity.
+ *
+ * Code adapted from https://github.com/tdebatty/java-string-similarity#jaro-winkler
+ */
+public class JaroWinkler {
+
+    private static final double DEFAULT_THRESHOLD = 0.7;
+    private static final int THREE = 3;
+    private static final double JW_COEF = 0.1;
+    private final double threshold;
+
+    /**
+     * Instantiate with default threshold (0.7).
+     *
+     */
+    public JaroWinkler() {
+        this.threshold = DEFAULT_THRESHOLD;
+    }
+
+    /**
+     * Instantiate with given threshold to determine when Winkler bonus should
+     * be used.
+     * Set threshold to a negative value to get the Jaro distance.
+     * @param threshold
+     */
+    public JaroWinkler(final double threshold) {
+        this.threshold = threshold;
+    }
+
+    /**
+     * Returns the current value of the threshold used for adding the Winkler
+     * bonus. The default value is 0.7.
+     *
+     * @return the current value of the threshold
+     */
+    public final double getThreshold() {
+        return threshold;
+    }
+
+    /**
+     * Compute Jaro-Winkler similarity.
+     * @param s1 The first string to compare.
+     * @param s2 The second string to compare.
+     * @return The Jaro-Winkler similarity in the range [0, 1]
+     * @throws NullPointerException if s1 or s2 is null.
+     */
+    public final double similarity(final String s1, final String s2) {
+        if (s1 == null) {
+            throw new NullPointerException("s1 must not be null");
+        }
+
+        if (s2 == null) {
+            throw new NullPointerException("s2 must not be null");
+        }
+
+        if (s1.equals(s2)) {
+            return 1;
+        }
+
+        int[] mtp = matches(s1, s2);
+        float m = mtp[0];
+        if (m == 0) {
+            return 0f;
+        }
+        double j = ((m / s1.length() + m / s2.length() + (m - mtp[1]) / m))
+                / THREE;
+        double jw = j;
+
+        if (j > getThreshold()) {
+            jw = j + Math.min(JW_COEF, 1.0 / mtp[THREE]) * mtp[2] * (1 - j);
+        }
+        return jw;
+    }
+
+
+    /**
+     * Return 1 - similarity.
+     * @param s1 The first string to compare.
+     * @param s2 The second string to compare.
+     * @return 1 - similarity.
+     * @throws NullPointerException if s1 or s2 is null.
+     */
+    public final double distance(final String s1, final String s2) {
+        return 1.0 - similarity(s1, s2);
+    }
+
+    private int[] matches(final String s1, final String s2) {
+        String max, min;
+        if (s1.length() > s2.length()) {
+            max = s1;
+            min = s2;
+        } else {
+            max = s2;
+            min = s1;
+        }
+        int range = Math.max(max.length() / 2 - 1, 0);
+        int[] match_indexes = new int[min.length()];
+        Arrays.fill(match_indexes, -1);
+        boolean[] match_flags = new boolean[max.length()];
+        int matches = 0;
+        for (int mi = 0; mi < min.length(); mi++) {
+            char c1 = min.charAt(mi);
+            for (int xi = Math.max(mi - range, 0),
+                 xn = Math.min(mi + range + 1, max.length());
+                 xi < xn;
+                 xi++) {
+                if (!match_flags[xi] && c1 == max.charAt(xi)) {
+                    match_indexes[mi] = xi;
+                    match_flags[xi] = true;
+                    matches++;
+                    break;
+                }
+            }
+        }
+        char[] ms1 = new char[matches];
+        char[] ms2 = new char[matches];
+        for (int i = 0, si = 0; i < min.length(); i++) {
+            if (match_indexes[i] != -1) {
+                ms1[si] = min.charAt(i);
+                si++;
+            }
+        }
+        for (int i = 0, si = 0; i < max.length(); i++) {
+            if (match_flags[i]) {
+                ms2[si] = max.charAt(i);
+                si++;
+            }
+        }
+        int transpositions = 0;
+        for (int mi = 0; mi < ms1.length; mi++) {
+            if (ms1[mi] != ms2[mi]) {
+                transpositions++;
+            }
+        }
+        int prefix = 0;
+        for (int mi = 0; mi < min.length(); mi++) {
+            if (s1.charAt(mi) == s2.charAt(mi)) {
+                prefix++;
+            } else {
+                break;
+            }
+        }
+        return new int[]{matches, transpositions / 2, prefix, max.length()};
+    }
+}
+

--- a/app/src/test/java/de/rampro/activitydiary/helpers/JaroWinklerTest.java
+++ b/app/src/test/java/de/rampro/activitydiary/helpers/JaroWinklerTest.java
@@ -1,0 +1,73 @@
+/*
+ * ActivityDiary
+ *
+ * Copyright (C) 2018 Raphael Mack http://www.raphael-mack.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.rampro.activitydiary.helpers;
+
+import org.apache.tools.ant.taskdefs.Jar;
+import org.junit.Test;
+
+import de.rampro.activitydiary.helpers.JaroWinkler;
+
+public class JaroWinklerTest {
+    JaroWinkler jw = new JaroWinkler(.7);
+
+    // .8 is used at the threshold for showing user similar name dialog
+
+    @Test
+    public void testCapitalization() {
+        String s = "Sleeping";
+        String s2 = "sleeping";
+        assert(jw.similarity(s,s2) > .8);
+    }
+
+    @Test
+    public void testShort() {
+        String s = "sl";
+        String s2 = "s";
+        assert(jw.similarity(s,s2) > .8);
+    }
+
+    @Test
+    public void testDash() {
+        String s = "Sleeping-well";
+        String s2 = "Sleeping";
+        assert(jw.similarity(s,s2) > .8);
+    }
+
+    @Test
+    public void testNumbers() {
+        String s = "Sleeping1";
+        String s2 = "Sleeping2";
+        assert(jw.similarity(s,s2) > .8);
+    }
+
+    @Test
+    public void testContained() {
+        String s = "onlaptopwork";
+        String s2 = "laptop";
+        assert(jw.similarity(s,s2) < .8);
+    }
+
+    @Test
+    public void testIdentical() {
+        String s = "sleeping";
+        String s2 = "sleeping";
+        assert(jw.similarity(s,s2) == 1.0);
+    }
+}


### PR DESCRIPTION
Add in a JaroWinkler Similarity test adapted from this github [repo](https://github.com/tdebatty/java-string-similarity) to test for similarly named activities during activity creation. 

Adds a JaroWinkler class in ``/helpers`` and a JaroWinklerTest class in ``test/helpers/``

A new Query is created for the similarity test that is run when the text in the activity name textbox is changed. If the metric returns a 1.0(meaning the text entered is identical to a previously entered activity) then checkContraints is called so that the previous name checking functionality is not affected. 